### PR TITLE
Remove non-existing parameter

### DIFF
--- a/gitlab-update-script.rb
+++ b/gitlab-update-script.rb
@@ -46,7 +46,8 @@ package_manager = "bundler"
 source = Dependabot::Source.new(
   provider: "gitlab",
   repo: repo_name,
-  directory: directory
+  directory: directory,
+  branch: nil
 )
 
 ##############################
@@ -55,7 +56,6 @@ source = Dependabot::Source.new(
 fetcher = Dependabot::FileFetchers.for_package_manager(package_manager).new(
   source: source,
   credentials: credentials,
-  target_branch: nil,
 )
 
 files = fetcher.files


### PR DESCRIPTION
I think it was removed in https://github.com/dependabot/dependabot-core/commit/e14e1d45652b393236f2acb53b0e1fef1ab2e860.