### PR TITLE
Add dummy username for gitlab source

### DIFF
--- a/gitlab-update-script.rb
+++ b/gitlab-update-script.rb
@@ -15,6 +15,7 @@ credentials =
     {
       "type" => "git_source",
       "host" => "gitlab.com",
+      "username" => ENV["GITLAB_USERNAME"],
       "password" => ENV["GITLAB_ACCESS_TOKEN"] # A Gitlab access token with API permission
     },
     {


### PR DESCRIPTION
Hei!

I got this crash when running the dependabot script:

```
/usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:147:in `fetch': Child process raised KeyError with message: key not found: "username" (Dependabot::SharedHelpers::ChildProcessFailed)
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:147:in `block in configure_git_credentials'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:144:in `each'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:144:in `configure_git_credentials'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:110:in `configure_git_to_use_https_with_credentials'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:102:in `with_git_configured'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler/latest_version_finder.rb:106:in `block in latest_git_version_details'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler/shared_bundler_helpers.rb:59:in `block (2 levels) in in_a_temporary_bundler_context'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:42:in `block in in_a_forked_process'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:40:in `fork'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:40:in `in_a_forked_process'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler/shared_bundler_helpers.rb:44:in `block in in_a_temporary_bundler_context'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:33:in `block (2 levels) in in_a_temporary_directory'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:33:in `chdir'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:33:in `block in in_a_temporary_directory'
	from /usr/local/lib/ruby/2.5.0/tmpdir.rb:89:in `mktmpdir'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/shared_helpers.rb:30:in `in_a_temporary_directory'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler/shared_bundler_helpers.rb:41:in `in_a_temporary_bundler_context'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler/latest_version_finder.rb:105:in `latest_git_version_details'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler/latest_version_finder.rb:52:in `fetch_latest_version_details'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler/latest_version_finder.rb:31:in `latest_version_details'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler.rb:99:in `latest_version_details'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/ruby/bundler.rb:49:in `updated_requirements'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/base.rb:104:in `updated_dependency_with_own_req_unlock'
	from /usr/local/bundle/bundler/gems/dependabot-core-211620be1cc9/lib/dependabot/update_checkers/base.rb:46:in `updated_dependencies'
	from /builds/deivid-rodriguez/nipanipa/bin/dependabot-script/gitlab-update-script.rb:104:in `block in <top (required)>'
	from /builds/deivid-rodriguez/nipanipa/bin/dependabot-script/gitlab-update-script.rb:80:in `each'
	from /builds/deivid-rodriguez/nipanipa/bin/dependabot-script/gitlab-update-script.rb:80:in `<top (required)>'
	from bin/dependabot:10:in `load'
	from bin/dependabot:10:in `<main>'
```

More of a blind guess, but adding a `username` like it's done in the "github" source seems to have fixed it? Does it make sense at all?