### PR TITLE
Remove unnecessary GITLAB_USERNAME env

### DIFF
--- a/gitlab-update-script.rb
+++ b/gitlab-update-script.rb
@@ -15,7 +15,7 @@ credentials =
     {
       "type" => "git_source",
       "host" => "gitlab.com",
-      "username" => ENV["GITLAB_USERNAME"],
+      "username" => "x-access-token",
       "password" => ENV["GITLAB_ACCESS_TOKEN"] # A Gitlab access token with API permission
     },
     {


### PR DESCRIPTION
The username that authors the PRs is the owner of the token with API permissions. As far as I've seen, what you pass here is irrelevant.

@greysteil Can you double check this? You told me this was necessary in #87, but I'm not seeing that behavior...