### PR TITLE
Separate environment variable for project path

### DIFF
--- a/gitlab-update-script.rb
+++ b/gitlab-update-script.rb
@@ -27,7 +27,7 @@ credentials =
 ]
 
 # Full name of the GitLab repo you want to create pull requests for.
-repo_name = "#{ENV["GITLAB_USERNAME"]}/#{ENV["PROJECT_NAME"]}"
+repo_name = ENV["PROJECT_PATH"] # gitlab-namespace/project
 
 # Directory where the base dependency files are.
 directory = "/"


### PR DESCRIPTION
On gitlab, the namespace need not be a user. Sometimes it can be a group, which can have several nesting levels. Also, sometimes a gitlab user might not run this script against a project under her name, so I
think it's better to use a separate variable for the project's path.