### PR TITLE
Depend on dependabot/omnibus to ensure all file fetchers are loaded

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -9,6 +9,7 @@ require "dependabot/file_parsers"
 require "dependabot/update_checkers"
 require "dependabot/file_updaters"
 require "dependabot/pull_request_creator"
+require "dependabot/omnibus"
 
 credentials = [
   {


### PR DESCRIPTION
A line like this was added to `update-script.rb` in b459fbb77fb1dfa578485ccfe06849a360b17e27.
Without this line, I cannot use the updater script with "cargo" as package manager anymore, as the `FileFetcher` cannot be created.