### PR TITLE
Keep should_remove_source_branch true for GitLab

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -174,7 +174,8 @@ dependencies.select(&:top_level?).each do |dep|
     g.accept_merge_request(
       source.repo,
       pull_request.iid,
-      merge_when_pipeline_succeeds: true
+      merge_when_pipeline_succeeds: true,
+      should_remove_source_branch: true
     )
   end
 end


### PR DESCRIPTION
Enforce core option erased by the default values of the new request 

https://github.com/dependabot/dependabot-core/blob/c038fa061bfa3c96607c3acd7b6a7173046f56c0/lib/dependabot/pull_request_creator/gitlab.rb#L124