### PR TITLE
Adding DIRECTORY_PATH Environment Variable 

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -22,7 +22,7 @@ credentials = [
 repo_name = ENV["PROJECT_PATH"] # namespace/project
 
 # Directory where the base dependency files are.
-directory = "/"
+directory = ENV["DIRECTORY_PATH"] || "/"
 
 # Name of the package manager you'd like to do the update for. Options are:
 # - bundler


### PR DESCRIPTION
Creating schedules in GitLab for mono-repos can be problematic, as the `package.json` or nuget packages may be in a directory different than root, which may raise the following exception `Dependabot::DependencyFileNotFound`.

In order to solve this, I've added an environment variable named `DIRECTORY_PATH`, and if it's not set, it'll default to the repo's root directory.