### PR TITLE
Add a way to assign Gitlab MRs to a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Thus `https://[gitlab.domain/org/dependabot-script-repo]/pipeline_schedules` das
   * `PACKAGE_MANAGER_SET`: `bundler,composer,npm_and_yarn`
 * If you'd like to specify the directory that contains the manifest file in the repository, you can set the following environment variable:
   * `DIRECTORY_PATH`: `/path/to/point`
+* If you'd like Merge Requests to be assigned to a user, set the following environment variable:
+  * `GITLAB_ASSIGNEE_ID`: Integer ID of the user to assign. This can be found at `https://gitlab.com/api/v4/users?username=<your username>`
 
 ## The scripts
 

--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -176,6 +176,7 @@ dependencies.select(&:top_level?).each do |dep|
     dependencies: updated_deps,
     files: updated_files,
     credentials: credentials,
+    assignee: ENV['GITLAB_ASSIGNEE_ID']&.to_i,
     label_language: true,
   )
   pull_request = pr_creator.create


### PR DESCRIPTION
I've setup this script in Gitlab, everything works well except I'm not getting email notifications when `dependabot` creates MRs. This is an attempt to fix that problem.

I'm not super familiar with `dependabot` or Ruby, please let me know if there's a better way to do this.