### PR TITLE
Add docs on how to run script within Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,46 @@ Build the helpers you want to use (you'll also need the corresponding language i
 
 If you run into any trouble with the above please create an issue!
 
+#### Running script with Docker
+
+##### Running script within container to bump dependencies
+
+If you don't want to setup the machine where the script will be executed, you could run the script within
+a `dependabot/dependabot-core` container.
+In order to do that, you'll have to pull the image from Docker Hub and mount your working directory into the container.
+You'll also have to set several environment variables to make the script work with your configuration, 
+as specified in the documentation.
+
+Steps:
+```shell
+$ docker pull dependabot/dependabot-core
+$ docker run -ti -w /home/dependabot/dependabot-script --env-file env.list -v "$(pwd):/home/dependabot/dependabot-script" dependabot/dependabot-core
+
+(Now you'd be inside the Docker container)
+/home/dependabot/dependabot-script# bundle install
+/home/dependabot/dependabot-script# ./generic-update-script.rb (Add '#!/usr/bin/env ruby' to execute the script from the shell)
+```
+
+Please notice that you'll have to create an `env.list` file with your environment properties. For example:
+
+```shell
+GITHUB_ENTERPRISE_ACCESS_TOKEN=xxxxxxxxx
+GITHUB_ENTERPRISE_HOSTNAME=mycompany.github.com
+PROJECT_PATH=myorganisation/project
+PACKAGE_MANAGER=gradle
+```
+
+You could also pass environment variables separately on your `docker run` command with `--env`.
+
+If everything goes well you should be able to see something like:
+
+```shell
+/home/dependabot/dependabot-script# ./generic-update-script.rb
+Fetching gradle dependency files for myorganisation/project
+Parsing dependencies information
+...
+```
+
 ### GitLab CI
 
 The easiest configuration is to have a repository dedicated to the script.

--- a/README.md
+++ b/README.md
@@ -66,25 +66,42 @@ You'll also have to set several environment variables to make the script work wi
 as specified in the documentation.
 
 Steps:
+
+1. Pull dependabot-core Docker image
+
 ```shell
 $ docker pull dependabot/dependabot-core
-$ docker run -ti -w /home/dependabot/dependabot-script --env-file env.list -v "$(pwd):/home/dependabot/dependabot-script" dependabot/dependabot-core
-
-(Now you'd be inside the Docker container)
-/home/dependabot/dependabot-script# bundle install
-/home/dependabot/dependabot-script# ./generic-update-script.rb (Add '#!/usr/bin/env ruby' to execute the script from the shell)
 ```
 
-Please notice that you'll have to create an `env.list` file with your environment properties. For example:
+2. Install dependencies
 
 ```shell
-GITHUB_ENTERPRISE_ACCESS_TOKEN=xxxxxxxxx
-GITHUB_ENTERPRISE_HOSTNAME=mycompany.github.com
-PROJECT_PATH=myorganisation/project
-PACKAGE_MANAGER=gradle
+docker run -v "$(pwd):/home/dependabot/dependabot-script" -w /home/dependabot/dependabot-script dependabot/dependabot-core bundle install -j 3 --path vendor
 ```
 
-You could also pass environment variables separately on your `docker run` command with `--env`.
+3. Run dependabot
+
+```shell
+docker run -v "$(pwd):/home/dependabot/dependabot-script" -w /home/dependabot/dependabot-script -e ENV_VARIABLE=value dependabot/dependabot-core bundle exec ruby ./generic-update-script.rb
+```
+
+You'll have to pass the right environment variables to make the script work with your configuration. You can find how to pass environment variables to your container in [Docker run reference](https://docs.docker.com/engine/reference/run/#env-environment-variables).
+
+You'll have to set some mandatory variables like `PROJECT_PATH` and `PACKAGE_MANAGER` (see [script](https://github.com/dependabot/dependabot-script/blob/master/generic-update-script.rb) to know more).
+There are other variables that you must pass to your container that will depend on the Git source you use:
+
+* Github
+    * GITHUB_ACCESS_TOKEN
+* Github Enterprise
+    * GITHUB_ENTERPRISE_HOSTNAME
+    * GITHUB_ENTERPRISE_ACCESS_TOKEN
+* Gitlab
+    * GITLAB_HOSTNAME: default value `gitlab.com`
+    * GITLAB_ACCESS_TOKEN
+* Azure DevOps
+    * AZURE_HOSTNAME: default value `dev.azure.com`
+    * AZURE_ACCESS_TOKEN
+
 
 If everything goes well you should be able to see something like:
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ If you run into any trouble with the above please create an issue!
 
 #### Running script with Docker
 
-##### Running script within container to bump dependencies
-
 If you don't want to setup the machine where the script will be executed, you could run the script within
 a `dependabot/dependabot-core` container.
 In order to do that, you'll have to pull the image from Docker Hub and mount your working directory into the container.


### PR DESCRIPTION
Found a bit confusing how to run Dependabot inside of a Docker container initially, so trying to make it clear with this PR.
One of the misunderstandings was the `Running with Docker` section in dependabot-core and the `docker-dev-shell` script. Not sure if other people are having the same iasue, but initially I didn't realise that the script was meant to be used to make changes on dependabot-core for developers and not to run dependabot against a git repo itself.