### PR TITLE
Removed unnecessary manual setting for GitLab CI

### DIFF
--- a/.gitlab-ci.example.yml
+++ b/.gitlab-ci.example.yml
@@ -9,7 +9,6 @@
 #
 # * Set in the schedule required variables
 #
-#     PROJECT_PATH = group/repository
 #     PACKAGE_MANAGER_SET = bundler,composer,npm_and_yarn
 #
 # https://github.com/dependabot/dependabot-script
@@ -19,6 +18,7 @@
   image: dependabot/dependabot-core
   variables:
     PACKAGE_MANAGER: $CI_JOB_NAME
+    PROJECT_PATH:    $CI_PROJECT_PATH
   before_script:
     - bundle install -j $(nproc) --path vendor
   script: bundle exec ruby ./generic-update-script.rb

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Thus `https://[gitlab.domain/org/dependabot-script-repo]/pipeline_schedules` das
 * [Set the required global variables](https://docs.gitlab.com/ee/ci/variables/#variables) used in [`./generic-update-script.rb`][generic-script].
 * Create [a pipeline schedule](https://docs.gitlab.com/ee/user/project/pipelines/schedules.html) for each managed repository.
 * Set in the schedule the required variables:
-  * `PROJECT_PATH`: `group/repository`
   * `PACKAGE_MANAGER_SET`: `bundler,composer,npm_and_yarn`
 * If you'd like to specify the directory that contains the manifest file in the repository, you can set the following environment variable:
   * `DIRECTORY_PATH`: `/path/to/point`


### PR DESCRIPTION
`CI_PROJECT_PATH` (same to `PROJECT_PATH`) is predefined since GitLab 8.10

c.f.

* https://docs.gitlab.com/ee/ci/variables/predefined_variables.html#variables-reference
* https://docs.gitlab.com/ee/ci/variables/#debug-logging

Unnecessary manual settings can be deleted by writing this setting in `.gitlab-ci.yml`