### PR TITLE
Enable feature to ignore specific gems

### DIFF
--- a/.gemignore
+++ b/.gemignore
@@ -1,0 +1,1 @@
+# One gem per line

--- a/.gemignore
+++ b/.gemignore
@@ -1,1 +1,2 @@
 # One gem per line
+

--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -126,6 +126,7 @@ parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
 )
 
 dependencies = parser.parse
+ignore = File.readlines('.gemignore')
 
 dependencies.select(&:top_level?).each do |dep|
   #########################################
@@ -138,6 +139,7 @@ dependencies.select(&:top_level?).each do |dep|
   )
 
   next if checker.up_to_date?
+  next if ignore.include? dep.name
 
   requirements_to_unlock =
     if !checker.requirements_unlocked_or_can_be?

--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -126,7 +126,7 @@ parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
 )
 
 dependencies = parser.parse
-ignore = File.readlines('.gemignore')
+ignore = File.read('.gemignore')
 
 dependencies.select(&:top_level?).each do |dep|
   #########################################


### PR DESCRIPTION
I'm having a small issue here about one of the gems that makes dependabot freezes forever.

To solve this I've created a gem ignore file and the script will skip the check of every gem included in that file.

Tested on Gitlab CI.