### PR TITLE
Update custom-ci-config-path URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Many pipeline schedules can be added on that single repo to manage multiple proj
 Thus `https://[gitlab.domain/org/dependabot-script-repo]/pipeline_schedules` dashboard becomes your own dependabot admin interface.
 
 * Clone or mirror this repository.
-* Copy `.gitlab-ci.example.yml` to `.gitlab-ci.yml` or set [a custom CI config path for direct usage](https://docs.gitlab.com/ee/user/project/pipelines/settings.html#custom-ci-configuration-path).
+* Copy `.gitlab-ci.example.yml` to `.gitlab-ci.yml` or set [a custom CI config path for direct usage](https://docs.gitlab.com/ee/ci/pipelines/settings.html#custom-cicd-configuration-path).
 * [Set the required global variables](https://docs.gitlab.com/ee/ci/variables/#variables) used in [`./generic-update-script.rb`][generic-script].
 * Create [a pipeline schedule](https://docs.gitlab.com/ee/user/project/pipelines/schedules.html) for each managed repository.
 * Set in the schedule the required variables:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Many pipeline schedules can be added on that single repo to manage multiple proj
 Thus `https://[gitlab.domain/org/dependabot-script-repo]/pipeline_schedules` dashboard becomes your own dependabot admin interface.
 
 * Clone or mirror this repository.
-* Copy `.gitlab-ci.example.yml` to `.gitlab-ci.yml` or set [a custom CI config path for direct usage](https://docs.gitlab.com/ee/user/project/pipelines/settings.html#custom-ci-config-path).
+* Copy `.gitlab-ci.example.yml` to `.gitlab-ci.yml` or set [a custom CI config path for direct usage](https://docs.gitlab.com/ee/user/project/pipelines/settings.html#custom-ci-configuration-path).
 * [Set the required global variables](https://docs.gitlab.com/ee/ci/variables/#variables) used in [`./generic-update-script.rb`][generic-script].
 * Create [a pipeline schedule](https://docs.gitlab.com/ee/user/project/pipelines/schedules.html) for each managed repository.
 * Set in the schedule the required variables:


### PR DESCRIPTION
The link for https://docs.gitlab.com/ee/user/project/pipelines/settings.html#custom-ci-config-path is not correct. It needs to be updated to https://docs.gitlab.com/ee/user/project/pipelines/settings.html#custom-ci-configuration-path