### PR TITLE
Add MAX_PULL_REQUESTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Parsing dependencies information
 ...
 ```
 
+#### Optional environment variables
+* `MAX_PULL_REQUESTS` : Limit of creating PullRequest (MergeRequest)
+  * default. no limit
+
 ### GitLab CI
 
 The easiest configuration is to have a repository dedicated to the script.

--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -127,6 +127,9 @@ parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
 
 dependencies = parser.parse
 
+max_pull_requests = ENV["MAX_PULL_REQUESTS"].to_i
+pull_requests_count = 0
+
 dependencies.select(&:top_level?).each do |dep|
   #########################################
   # Get update details for the dependency #
@@ -183,6 +186,12 @@ dependencies.select(&:top_level?).each do |dep|
   puts " submitted"
 
   next unless pull_request
+
+  pull_requests_count += 1
+  if max_pull_requests > 0 && pull_requests_count >= max_pull_requests
+    puts " Limit of PullRequests (MAX_PULL_REQUESTS=#{max_pull_requests})"
+    break
+  end
 
   # Enable GitLab "merge when pipeline succeeds" feature.
   # Merge requests created and successfully tested will be merge automatically.


### PR DESCRIPTION
This option is the same function as Rate limiting of https://dependabot.com/ settings

![image](https://user-images.githubusercontent.com/608755/73284065-58e10d80-4237-11ea-9136-f58db6864afe.png)

# Context
I use `dependabot-script` in GitLabCI.

If I create many MergeRequests at once, build queue often will be clogged.
So I want to limit the maximum of PullRequests and MergeRequests.

Thank you.