### PR TITLE
fix: prevents an empty assignees list

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -178,7 +178,7 @@ dependencies.select(&:top_level?).each do |dep|
     dependencies: updated_deps,
     files: updated_files,
     credentials: credentials,
-    assignees: assignees
+    assignees: assignees,
     label_language: true,
   )
   pull_request = pr_creator.create

--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -170,13 +170,15 @@ dependencies.select(&:top_level?).each do |dep|
   ########################################
   # Create a pull request for the update #
   ########################################
+  assignee = (ENV["PULL_REQUESTS_ASSIGNEE"] || ENV["GITLAB_ASSIGNEE_ID"])&.to_i
+  assignees = assignee ? [assignee] : assignee
   pr_creator = Dependabot::PullRequestCreator.new(
     source: source,
     base_commit: commit,
     dependencies: updated_deps,
     files: updated_files,
     credentials: credentials,
-    assignees: [(ENV["PULL_REQUESTS_ASSIGNEE"] || ENV["GITLAB_ASSIGNEE_ID"])&.to_i],
+    assignees: assignees
     label_language: true,
   )
   pull_request = pr_creator.create


### PR DESCRIPTION
As reported in https://github.com/dependabot/dependabot-core/issues/1732 sending an empty array `[nil]` results in error.

If there is no `assignee` prevent from sending an array.