### PR TITLE
Auto retry when `merge when pipeline succeeds` is failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Thus `https://[gitlab.domain/org/dependabot-script-repo]/pipeline_schedules` das
   * `DIRECTORY_PATH`: `/path/to/point`
 * If you'd like Merge Requests to be assigned to a user, set the following environment variable:
   * `PULL_REQUESTS_ASSIGNEE`: Integer ID of the user to assign. This can be found at `https://gitlab.com/api/v4/users?username=<your username>`
+* `GITLAB_MAX_RETRY_COUNT` : Auto retry when `merge when pipeline succeeds` is failed
+  * default. `3`
 
 ## The scripts
 


### PR DESCRIPTION
Running `accept_merge_request` immediately after creating an GitLab MergeRequest often fails.

e.g.

```
Parsing dependencies information
  - Updating github.com/xanzy/go-gitlab (from 0.43.0)…/builds/sue445/dependabot-script/vendor/ruby/2.6.0/gems/gitlab-4.12.0/lib/gitlab/request.rb:54:in `validate': Server responded with code 405, message: 405 Method Not Allowed. Request URI: https://gitlab.com/api/v4/projects/sue445%2Ftanuki_reminder/merge_requests/82/merge (Gitlab::Error::MethodNotAllowed)
	from /builds/sue445/dependabot-script/vendor/ruby/2.6.0/gems/gitlab-4.12.0/lib/gitlab/request.rb:46:in `block (2 levels) in <class:Request>'
	from /builds/sue445/dependabot-script/vendor/ruby/2.6.0/gems/gitlab-4.12.0/lib/gitlab/client/merge_requests.rb:121:in `accept_merge_request'
	from ./generic-update-script.rb:194:in `block in <main>'
	from ./generic-update-script.rb:130:in `each'
	from ./generic-update-script.rb:130:in `<main>'
```

c.f. 

* #528
* https://gitlab.com/sue445/dependabot-script/-/jobs/1028982896#L129

So I added retry process to solve this problem by retrying.

This workarround is working in my gem.
https://gitlab.com/sue445/gitlabci-bundle-update-mr/-/blob/v1.1.2/lib/gitlabci/bundle/update/mr/client.rb#L219