### PR TITLE
Fix .gitlab-ci.example.yml

### DIFF
--- a/.gitlab-ci.example.yml
+++ b/.gitlab-ci.example.yml
@@ -122,4 +122,4 @@ github_actions:
   extends: .dependabot
   only:
     variables:
-      - $PACKAGE_MANAGER_SET =~ /\github_actions\b/
+      - $PACKAGE_MANAGER_SET =~ /\bgithub_actions\b/

--- a/.gitlab-ci.example.yml
+++ b/.gitlab-ci.example.yml
@@ -15,7 +15,6 @@
 # https://github.com/dependabot/dependabot-script
 # https://docs.gitlab.com/ee/ci/yaml/
 
-.dependabot:
 build-image:
   stage: build
   script:

--- a/.gitlab-ci.example.yml
+++ b/.gitlab-ci.example.yml
@@ -16,15 +16,15 @@
 # https://docs.gitlab.com/ee/ci/yaml/
 
 .dependabot:
-  image: dependabot/dependabot-core
+  build_image:
+  script:
+    - docker docker build -t "dependabot/dependabot-script" -f Dockerfile .
+    - docker run --rm \
+        --env "PROJECT_PATH=$PROJECT_PATH" \
+        --env "PACKAGE_MANAGER=$PACKAGE_MANAGER" \
+        "dependabot/dependabot-script"
   variables:
     PACKAGE_MANAGER: $CI_JOB_NAME
-  before_script:
-    - bundle install -j $(nproc) --path vendor
-  script: bundle exec ruby ./generic-update-script.rb
-  cache:
-    paths:
-      - vendor/
   only:
     - schedules
 
@@ -117,3 +117,9 @@ terraform:
   only:
     variables:
       - $PACKAGE_MANAGER_SET =~ /\bterraform\b/
+
+github_actions:
+  extends: .dependabot
+  only:
+    variables:
+      - $PACKAGE_MANAGER_SET =~ /\github_actions\b/

--- a/.gitlab-ci.example.yml
+++ b/.gitlab-ci.example.yml
@@ -16,15 +16,17 @@
 # https://docs.gitlab.com/ee/ci/yaml/
 
 .dependabot:
-  build_image:
-    script:
-      - docker docker build -t "dependabot/dependabot-script" -f Dockerfile .
-      - docker run --rm \
-          --env "PROJECT_PATH=$PROJECT_PATH" \
-          --env "PACKAGE_MANAGER=$PACKAGE_MANAGER" \
-          "dependabot/dependabot-script"
+build-image:
+  stage: build
+  script:
+    - docker build -t "dependabot/dependabot-script" -f Dockerfile .
+
+.dependabot:
+  image: dependabot/dependabot-script
   variables:
     PACKAGE_MANAGER: $CI_JOB_NAME
+  script:
+    - bundle exec ruby ./generic-update-script.rb
   only:
     - schedules
 

--- a/.gitlab-ci.example.yml
+++ b/.gitlab-ci.example.yml
@@ -17,12 +17,12 @@
 
 .dependabot:
   build_image:
-  script:
-    - docker docker build -t "dependabot/dependabot-script" -f Dockerfile .
-    - docker run --rm \
-        --env "PROJECT_PATH=$PROJECT_PATH" \
-        --env "PACKAGE_MANAGER=$PACKAGE_MANAGER" \
-        "dependabot/dependabot-script"
+    script:
+      - docker docker build -t "dependabot/dependabot-script" -f Dockerfile .
+      - docker run --rm \
+          --env "PROJECT_PATH=$PROJECT_PATH" \
+          --env "PACKAGE_MANAGER=$PACKAGE_MANAGER" \
+          "dependabot/dependabot-script"
   variables:
     PACKAGE_MANAGER: $CI_JOB_NAME
   only:


### PR DESCRIPTION
Attempting to fix gitlab ci example to build the dockerfile.

The setup changed here: https://github.com/dependabot/dependabot-script/commit/cdb88170148c734c93597ca5a7e694e19e70113e

`dependabot-core` now builds a Dockerfile with a `dependabot` user with less permissions so any wrapping image will need to make sure files are owned by this user.