### PR TITLE
[GitLab CI] Add base image for `docker build`

### DIFF
--- a/.gitlab-ci.example.yml
+++ b/.gitlab-ci.example.yml
@@ -16,7 +16,10 @@
 # https://docs.gitlab.com/ee/ci/yaml/
 
 build-image:
+  image: docker:latest
   stage: build
+  services:
+    - docker:dind
   script:
     - docker build -t "dependabot/dependabot-script" -f Dockerfile .
 


### PR DESCRIPTION
# Context
I'm testing for #383 on my GitLab repo.

I used [.gitlab-ci.example.yml](https://github.com/dependabot/dependabot-script/blob/9955ecfde6514d412aad052e7d5809af2039fb80/.gitlab-ci.example.yml) on my repo, `build-image` job is failed.

```
$ docker build -t "dependabot/dependabot-script" -f Dockerfile .
/bin/bash: line 117: docker: command not found
```

c.f. https://gitlab.com/sue445/dependabot-script-for-patch-383/-/jobs/1195940009#L24

# Why?
When `image` in `.gitlab-ci.yml` job is omitted, docker image is used which defined in `/etc/gitlab-runner/config.toml` (GitLab Runner config file)

https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersdocker-section

So I added a few configs.

This refers on GitLab's official template file

c.f. https://gitlab.com/gitlab-org/gitlab/-/blob/v13.10.3-ee/lib/gitlab/ci/templates/Docker.gitlab-ci.yml