### PR TITLE
Use docker image for gitlab CI

### DIFF
--- a/.gitlab-ci.example.yml
+++ b/.gitlab-ci.example.yml
@@ -14,6 +14,8 @@
 #
 # https://github.com/dependabot/dependabot-script
 # https://docs.gitlab.com/ee/ci/yaml/
+default:
+  image: docker:latest
 
 build-image:
   stage: build


### PR DESCRIPTION
There are a problem with some version of Gitlab because the default image don't include Docker