### PR TITLE
Add small pause before sending auto merge request

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -229,6 +229,7 @@ dependencies.select(&:top_level?).each do |dep|
   # Enable GitLab "merge when pipeline succeeds" feature.
   # Merge requests created and successfully tested will be merge automatically.
   if ENV["GITLAB_AUTO_MERGE"]
+    sleep 15
     g = Gitlab.client(
       endpoint: source.api_endpoint,
       private_token: ENV["GITLAB_ACCESS_TOKEN"]


### PR DESCRIPTION
I have consistently come across a 405 when using this script with merge_when_pipeline_succeeds. This seems to be a common issue even with the multiple fixes that have been provided. From what I have seen, the 405 is from accepting the MR before its ready. This pause - which may be able to be shortened - has allowed me to utilize the merge_when_pipeline_succeeds flag on my Gitlab instance.