### PR TITLE
Change bot email address  to `nil`

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -218,7 +218,7 @@ dependencies.select(&:top_level?).each do |dep|
     files: updated_files,
     credentials: credentials,
     assignees: assignees,
-    author_details: { name: "Dependabot", email: "no-reply@github.com" },
+    author_details: { name: "Dependabot", email: nil },
     label_language: true,
   )
   pull_request = pr_creator.create


### PR DESCRIPTION
Dependabot doesn't have an actual email, and commiting as `"no-reply@github.com"` just doesn't seem like the right move.
At least Bitbucket API accepted commits with both `"Dependabot"` as email and `nil` as email. Assuming other platforms are fine with that too, I think it makes sense for the bot to just not use an email address at all, at least by default.