### PR TITLE
Small fixes to Bitbucket support

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -103,7 +103,7 @@ elsif ENV["BITBUCKET_ACCESS_TOKEN"]
   credentials << {
     "type" => "git_source",
     "host" => bitbucket_hostname,
-    "username" => nil,
+    "username" => "x-token-auth",
     "token" => ENV["BITBUCKET_ACCESS_TOKEN"]
   }
 


### PR DESCRIPTION
- Don't ignore target branch name when creating a Bitbucket PR
- Use x-token-auth as username when authenticating to Bitbucket using a token (Fix #664)