### PR TITLE
Remove broken image url / badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dependabot Update Script [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&identifier=131328855)](https://dependabot.com)
+# Dependabot Update Script
 
 This repo contains two scripts that demonstrates
 [Dependabot Core][dependabot-core]. It is intended to give you a feel for how


### PR DESCRIPTION
The underlying URL here is from before Dependabot was acquired by GitHub,
when everything ran on dependabot.com. Now that we run on different infra,
the badge image is broken.

I considered fixing the badge URL, but as best I can tell the API calls on
GitHub are a bit different, so this is no longer an "app" run against the Dependabot API.

So I removed it altogether.

Perhaps down the road we could update it to be a "test app" run against the
Dependabot API, and add the badge back then.

Fix #776