### PR TITLE
Update the gitlab help doc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Many pipeline schedules can be added on that single repo to manage multiple proj
 Thus `https://[gitlab.domain/org/dependabot-script-repo]/pipeline_schedules` dashboard becomes your own dependabot admin interface.
 
 * Clone or mirror this repository.
-* Copy `.gitlab-ci.example.yml` to `.gitlab-ci.yml` or set [a custom CI config path for direct usage](https://docs.gitlab.com/ee/user/project/pipelines/settings.html#custom-ci-config-path).
+* Copy `.gitlab-ci.example.yml` to `.gitlab-ci.yml` or set [a custom CI config path for direct usage](https://docs.gitlab.com/ee/user/project/pipelines/settings.html#custom-ci-configuration-path).
 * [Set the required global variables](https://docs.gitlab.com/ee/ci/variables/#variables) used in [`./generic-update-script.rb`][generic-script].
 * Create [a pipeline schedule](https://docs.gitlab.com/ee/user/project/pipelines/schedules.html) for each managed repository.
 * Set in the schedule the required variables:

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Many pipeline schedules can be added on that single repo to manage multiple proj
 Thus `https://[gitlab.domain/org/dependabot-script-repo]/pipeline_schedules` dashboard becomes your own dependabot admin interface.
 
 * Clone or mirror this repository.
-* Copy `.gitlab-ci.example.yml` to `.gitlab-ci.yml` or set [a custom CI config path for direct usage](https://docs.gitlab.com/ee/user/project/pipelines/settings.html#custom-ci-configuration-path).
+* Copy `.gitlab-ci.example.yml` to `.gitlab-ci.yml` or set [a custom CI config path for direct usage](https://docs.gitlab.com/ee/ci/pipelines/settings.html#specify-a-custom-cicd-configuration-file).
 * [Set the required global variables](https://docs.gitlab.com/ee/ci/variables/#variables) used in [`./generic-update-script.rb`][generic-script].
 * Create [a pipeline schedule](https://docs.gitlab.com/ee/user/project/pipelines/schedules.html) for each managed repository.
 * Set in the schedule the required variables:


### PR DESCRIPTION
When the default branch was switched from `master` to `main`, it looks like https://github.com/dependabot/dependabot-script/pull/405 was somehow missed.

So I cherry-picked that over to ensure that @jeff-cook gets credit, and then did a follow-on commit since the URL has changed once again.

Once this is merged, there should be no difference between `master`/`main`, so we can safely delete `master` and fix #559 