### PR TITLE
Fix BitBucket username for token auth

### DIFF
--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -108,7 +108,7 @@ elsif ENV["BITBUCKET_ACCESS_TOKEN"]
   credentials << {
     "type" => "git_source",
     "host" => bitbucket_hostname,
-    "username" => nil,
+    "username" => "x-token-auth",
     "token" => ENV["BITBUCKET_ACCESS_TOKEN"]
   }
 


### PR DESCRIPTION
From the [BitBucket docs](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/):
> The literal string `x-token-auth` as a substitute for username is required.

Copied from https://github.com/dependabot/dependabot-script/pull/736/files#diff-6b47430943f20b3a1a6dd41cd62be1602657b8becf8bb99c66693c85678e671dR106

Fix https://github.com/dependabot/dependabot-script/issues/664

Co-authored-by: @rimas-kudelis