### PR TITLE
Add support for configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Variable Name             | Default          | Notes
 `BRANCH         `         | N/A (Optional) | Branch to fetch manifest from and open pull requests against.
 `PULL_REQUESTS_ASSIGNEE`  | N/A (Optional) | User to assign to the created pull request.
 `OPTIONS`                 | `{}`           | JSON options to customize the operation of Dependabot
+`USE_CONFIG`              | `false`        | Whether to use dependabot.yml configuration file. Valid values are `true` and `false`.
 
 There are other variables that you must pass to your container that will depend on the Git source you use:
 

--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -247,7 +247,8 @@ dependencies.select(&:top_level?).each do |dep|
   ########################################
   # Create a pull request for the update #
   ########################################
-  assignee = (ENV["PULL_REQUESTS_ASSIGNEE"] || ENV["GITLAB_ASSIGNEE_ID"])&.to_i
+  assignee = (ENV["PULL_REQUESTS_ASSIGNEE"] || ENV["GITLAB_ASSIGNEE_ID"])
+  assignee = assignee&.to_i.to_s == assignee ? assignee&.to_i : assignee
   assignees = assignee ? [assignee] : assignee
   pr_creator = Dependabot::PullRequestCreator.new(
     source: source,


### PR DESCRIPTION
This should close #716 and #678.

A first use-case of adding support for `dependabot.yml` is to be able to ignore certain packages/versions.