### PR TITLE
Add credentials via environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Variable Name             | Default          | Notes
 `BRANCH         `         | N/A (Optional) | Branch to fetch manifest from and open pull requests against.
 `PULL_REQUESTS_ASSIGNEE`  | N/A (Optional) | User to assign to the created pull request.
 `OPTIONS`                 | `{}`           | JSON options to customize the operation of Dependabot
+`CREDENTIALS`             | `[]`            | JSON array containing credentials that can be used to specify what additional resources Dependabot can access and how it can access them.
+
+The content of both the OPTIONS and CREDENTIALS variables depend on the selected package manager. For example, when using "maven", the CREDENTIALS variable can be used to specify an
+additional repository or to completely replace the default maven central repository with a custom one:
+
+```shell
+export CREDENTIALS='[{"type": "maven_repository", "url": "https://example.com/maven", "replaces-base": true}]'
+```
 
 There are other variables that you must pass to your container that will depend on the Git source you use:
 

--- a/generic-update-script.rb
+++ b/generic-update-script.rb
@@ -10,14 +10,15 @@ require "dependabot/omnibus"
 require "gitlab"
 require "json"
 
-credentials = [
-  {
-    "type" => "git_source",
-    "host" => "github.com",
-    "username" => "x-access-token",
-    "password" => ENV["GITHUB_ACCESS_TOKEN"] # A GitHub access token with read access to public repos
-  }
-]
+# Get optional credentials from the environment variable called CREDENTIALS (json array).
+credentials = JSON.parse(ENV["CREDENTIALS"] || "[]")
+
+credentials << {
+  "type" => "git_source",
+  "host" => "github.com",
+  "username" => "x-access-token",
+  "password" => ENV["GITHUB_ACCESS_TOKEN"] # A GitHub access token with read access to public repos
+}
 
 # Full name of the repo you want to create pull requests for.
 repo_name = ENV["PROJECT_PATH"] # namespace/project


### PR DESCRIPTION
This PR enables the ability to pass additional credentials to Dependabot through the generic-update-script.rb. This is needed to be able to use the script in a self-hosted environment with maven, where Dependabot needs to access one or more private repositories without having to specify the repositories in the pom.xml file of each maven project within the environment. As the 'credentials' parameter is not specific to the maven parser/fetcher, it will likely be useful for other package managers as well.