### PR TITLE
Pull `dependabot-core` image from GHCR instead of Dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dependabot/dependabot-core:0.215.0
+FROM ghcr.io/dependabot/dependabot-core:0.215.0
 
 ARG CODE_DIR=/home/dependabot/dependabot-script
 RUN mkdir -p ${CODE_DIR}


### PR DESCRIPTION
We have been publishing to both GHCR and also Dockerhub.

I was cleaning up our DockerHub presence and I nuked the https://hub.docker.com/u/dependabot/dependabot-core repository because:

1. we stopped publishing new versions of this image 3 months ago when we split the monolothic image
2. we don't plan to publish this image in the future, we'd update the scripts to use the per-ecosystem images instead
3. It'll be confusing down the road _if_ we do start publishing images to have this image floating around on dockerhub, not clear how this image would differ from the `dependabot-updater-core` image.
4. the image is still available on GHCR registry for anyone who really needs it.

I didn't realize this repo hadn't yet been migrated to point at the GHCR registry for pulling it.

We still haven't invested the time to unblock folks on pulling images using the per-ecosystem images, but let's at least not have it completely broken for folks willing to use older versions of the images...